### PR TITLE
feat: Vue 3 を Vite + Laravel に統合し、基本コンポーネントを表示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "vue": "^3.5.17"
+            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.0.0",
@@ -42,6 +45,52 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+            "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.0"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.28.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+            "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -542,7 +591,6 @@
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
             "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -1196,6 +1244,80 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
+            "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.27.5",
+                "@vue/shared": "3.5.17",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
+            "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.17",
+                "@vue/shared": "3.5.17"
+            }
+        },
+        "node_modules/@vue/compiler-dom/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
+            "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.27.5",
+                "@vue/compiler-core": "3.5.17",
+                "@vue/compiler-dom": "3.5.17",
+                "@vue/compiler-ssr": "3.5.17",
+                "@vue/shared": "3.5.17",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.17",
+                "postcss": "^8.5.6",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
+            "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.17",
+                "@vue/shared": "3.5.17"
+            }
+        },
+        "node_modules/@vue/compiler-ssr/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
+        },
         "node_modules/@vue/reactivity": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
@@ -1205,6 +1327,77 @@
             "dependencies": {
                 "@vue/shared": "3.1.5"
             }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.17.tgz",
+            "integrity": "sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.17",
+                "@vue/shared": "3.5.17"
+            }
+        },
+        "node_modules/@vue/runtime-core/node_modules/@vue/reactivity": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.17.tgz",
+            "integrity": "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.5.17"
+            }
+        },
+        "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.17.tgz",
+            "integrity": "sha512-8El0M60TcwZ1QMz4/os2MdlQECgGoVHPuLnQBU3m9h3gdNRW9xRmI8iLS4t/22OQlOE6aJvNNlBiCzPHur4H9g==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.17",
+                "@vue/runtime-core": "3.5.17",
+                "@vue/shared": "3.5.17",
+                "csstype": "^3.1.3"
+            }
+        },
+        "node_modules/@vue/runtime-dom/node_modules/@vue/reactivity": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.17.tgz",
+            "integrity": "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.5.17"
+            }
+        },
+        "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.17.tgz",
+            "integrity": "sha512-BOHhm8HalujY6lmC3DbqF6uXN/K00uWiEeF22LfEsm9Q93XeJ/plHTepGwf6tqFcF7GA5oGSSAAUock3VvzaCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.17",
+                "@vue/shared": "3.5.17"
+            },
+            "peerDependencies": {
+                "vue": "3.5.17"
+            }
+        },
+        "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
         },
         "node_modules/@vue/shared": {
             "version": "3.1.5",
@@ -1711,6 +1904,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1793,6 +1992,18 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/es-define-property": {
@@ -1895,6 +2106,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -2600,7 +2817,6 @@
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -2744,7 +2960,6 @@
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2851,7 +3066,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -2891,7 +3105,6 @@
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
             "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -3257,7 +3470,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -3751,6 +3963,33 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
+        },
+        "node_modules/vue": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
+            "integrity": "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.17",
+                "@vue/compiler-sfc": "3.5.17",
+                "@vue/runtime-dom": "3.5.17",
+                "@vue/server-renderer": "3.5.17",
+                "@vue/shared": "3.5.17"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vue/node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+            "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,10 @@
     "requires": true,
     "packages": {
         "": {
-            "dependencies": {
-                "vue": "^3.5.17"
-            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.0.0",
+                "@vitejs/plugin-vue": "^6.0.0",
                 "alpinejs": "^3.4.2",
                 "autoprefixer": "^10.4.2",
                 "axios": "^1.8.2",
@@ -17,7 +15,8 @@
                 "laravel-vite-plugin": "^1.2.0",
                 "postcss": "^8.4.31",
                 "tailwindcss": "^3.1.0",
-                "vite": "^6.2.4"
+                "vite": "^6.2.4",
+                "vue": "^3.5.17"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -51,6 +50,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -60,6 +60,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
             "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -69,6 +70,7 @@
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
             "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.28.0"
@@ -84,6 +86,7 @@
             "version": "7.28.1",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
             "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -591,6 +594,7 @@
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
             "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -652,6 +656,13 @@
             "engines": {
                 "node": ">=14"
             }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.19",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
+            "integrity": "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.45.0",
@@ -1244,10 +1255,28 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@vitejs/plugin-vue": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.0.tgz",
+            "integrity": "sha512-iAliE72WsdhjzTOp2DtvKThq1VBC4REhwRcaA+zPAAph6I+OQhUXv+Xu2KS7ElxYtb7Zc/3R30Hwv1DxEo7NXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "1.0.0-beta.19"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "vue": "^3.2.25"
+            }
+        },
         "node_modules/@vue/compiler-core": {
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
             "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.27.5",
@@ -1261,12 +1290,14 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/compiler-dom": {
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
             "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-core": "3.5.17",
@@ -1277,12 +1308,14 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/compiler-sfc": {
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
             "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.27.5",
@@ -1300,12 +1333,14 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/compiler-ssr": {
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
             "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.17",
@@ -1316,6 +1351,7 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/reactivity": {
@@ -1332,6 +1368,7 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.17.tgz",
             "integrity": "sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.17",
@@ -1342,6 +1379,7 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.17.tgz",
             "integrity": "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/shared": "3.5.17"
@@ -1351,12 +1389,14 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/runtime-dom": {
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.17.tgz",
             "integrity": "sha512-8El0M60TcwZ1QMz4/os2MdlQECgGoVHPuLnQBU3m9h3gdNRW9xRmI8iLS4t/22OQlOE6aJvNNlBiCzPHur4H9g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.17",
@@ -1369,6 +1409,7 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.17.tgz",
             "integrity": "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/shared": "3.5.17"
@@ -1378,12 +1419,14 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/server-renderer": {
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.17.tgz",
             "integrity": "sha512-BOHhm8HalujY6lmC3DbqF6uXN/K00uWiEeF22LfEsm9Q93XeJ/plHTepGwf6tqFcF7GA5oGSSAAUock3VvzaCA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-ssr": "3.5.17",
@@ -1397,6 +1440,7 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/shared": {
@@ -1908,6 +1952,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/delayed-stream": {
@@ -1998,6 +2043,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -2111,6 +2157,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
@@ -2817,6 +2864,7 @@
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -2960,6 +3008,7 @@
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3066,6 +3115,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -3105,6 +3155,7 @@
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
             "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -3470,6 +3521,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -3968,6 +4020,7 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
             "integrity": "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.17",
@@ -3989,6 +4042,7 @@
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
             "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
         "postcss": "^8.4.31",
         "tailwindcss": "^3.1.0",
         "vite": "^6.2.4"
+    },
+    "dependencies": {
+        "vue": "^3.5.17"
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/vite": "^4.0.0",
+        "@vitejs/plugin-vue": "^6.0.0",
         "alpinejs": "^3.4.2",
         "autoprefixer": "^10.4.2",
         "axios": "^1.8.2",
@@ -16,9 +17,7 @@
         "laravel-vite-plugin": "^1.2.0",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.1.0",
-        "vite": "^6.2.4"
-    },
-    "dependencies": {
+        "vite": "^6.2.4",
         "vue": "^3.5.17"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,7 +1,7 @@
-import './bootstrap';
+import { createApp } from "vue";
+import ExampleComponent from "./components/ExampleComponent.vue";
 
-import Alpine from 'alpinejs';
-
-window.Alpine = Alpine;
-
-Alpine.start();
+const el = document.getElementById("example");
+if (el) {
+    createApp(ExampleComponent).mount(el);
+}

--- a/resources/js/components/ExampleComponent.vue
+++ b/resources/js/components/ExampleComponent.vue
@@ -1,0 +1,6 @@
+<script>
+export default { name: "EcampleComponent" };
+</script>
+<template>
+    <div>Hello from vue!</div>
+</template>

--- a/resources/js/components/ExampleComponent.vue
+++ b/resources/js/components/ExampleComponent.vue
@@ -1,5 +1,5 @@
 <script>
-export default { name: "EcampleComponent" };
+export default { name: "ExampleComponent" };
 </script>
 <template>
     <div>Hello from vue!</div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -20,6 +20,9 @@
         @endif
     </head>
     <body class="bg-[#FDFDFC] dark:bg-[#0a0a0a] text-[#1b1b18] flex p-6 lg:p-8 items-center lg:justify-center min-h-screen flex-col">
+        <!-- vueをマウントする場所 -->
+        <div id="example"></div>
+        
         <header class="w-full lg:max-w-4xl max-w-[335px] text-sm mb-6 not-has-[nav]:hidden">
             @if (Route::has('login'))
                 <nav class="flex items-center justify-end gap-4">
@@ -273,5 +276,8 @@
         @if (Route::has('login'))
             <div class="h-14.5 hidden lg:block"></div>
         @endif
+
+    <!-- viteでビルドされたJS読み込み -->
+    @vite('resources/js/app.js')
     </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,13 @@
-import { defineConfig } from 'vite';
-import laravel from 'laravel-vite-plugin';
+import vue from "@vitejs/plugin-vue";
+import laravel from "laravel-vite-plugin";
+import { defineConfig } from "vite";
 
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ["resources/css/app.css", "resources/js/app.js"],
             refresh: true,
         }),
+        vue(),
     ],
 });


### PR DESCRIPTION
# Laravel + Vite プロジェクトに Vue 3 を導入

## 主な変更点

---

- **Vue 3 および Vite プラグインの導入**
  - `package.json` に `vue` と `@vitejs/plugin-vue` を追加  
- **Vite 設定の更新**
  - `vite.config.js` に `vue()` プラグインを追加し、Vue コンポーネントを認識できるように設定
- **Vue アプリの初期化**
  - `resources/js/app.js` を Vue アプリの初期化コードに変更し、`#example` にコンポーネントをマウント
- **サンプルコンポーネントの追加**
  - `ExampleComponent.vue` を新規作成し、"Hello from vue!" を表示
- **Blade テンプレートの修正**
  - `welcome.blade.php` に Vue のマウント用 `<div id="example"></div>` と `@vite` のスクリプトタグを追加

---

## 補足

- 今後、Vue コンポーネントベースで柔軟な UI 構築が可能になります。
- 既存の Alpine.js は一旦削除していますが、必要に応じて再導入可能です。
- 構成の整合性のため `bootstrap.js` のインポートも削除しています。
