### PR TITLE
feat: add-migration

### DIFF
--- a/app/Models/BatterStat.php
+++ b/app/Models/BatterStat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BatterStat extends Model
+{
+    //
+}

--- a/app/Models/ExternalApiSource.php
+++ b/app/Models/ExternalApiSource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ExternalApiSource extends Model
+{
+    //
+}

--- a/app/Models/Favorite.php
+++ b/app/Models/Favorite.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Favorite extends Model
+{
+    //
+}

--- a/app/Models/PitcherStat.php
+++ b/app/Models/PitcherStat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PitcherStat extends Model
+{
+    //
+}

--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Player extends Model
+{
+    //
+}

--- a/app/Models/PlayerPosition.php
+++ b/app/Models/PlayerPosition.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PlayerPosition extends Model
+{
+    //
+}

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Position extends Model
+{
+    //
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    //
+}

--- a/database/migrations/2025_07_13_230142_create_teams_table.php
+++ b/database/migrations/2025_07_13_230142_create_teams_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('abbreviation')->nullable();
+            $table->string('logo_url')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/database/migrations/2025_07_13_230805_create_players_table.php
+++ b/database/migrations/2025_07_13_230805_create_players_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('players', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('team_id')->constrained()->onDelete('cascade');
+            $table->integer('number')->nullable();
+            $table->string('photo_url')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('players');
+    }
+};

--- a/database/migrations/2025_07_13_231227_create_positions_table.php
+++ b/database/migrations/2025_07_13_231227_create_positions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('positions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('abbreviation')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('positions');
+    }
+};

--- a/database/migrations/2025_07_13_231545_create_player_positions_table.php
+++ b/database/migrations/2025_07_13_231545_create_player_positions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('player_positions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->foreignId('position_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('player_positions');
+    }
+};

--- a/database/migrations/2025_07_13_235615_create_batter_stats_table.php
+++ b/database/migrations/2025_07_13_235615_create_batter_stats_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('batter_stats', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->date('match_date');
+            $table->string('opponent_team');
+            $table->integer('at_bats')->default(0);
+            $table->integer('hits')->default(0);
+            $table->integer('home_runs')->default(0);
+            $table->integer('rbi')->default(0);
+            $table->integer('strikeouts')->default(0);
+            $table->integer('walks')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('batter_stats');
+    }
+};

--- a/database/migrations/2025_07_13_235713_create_pitcher_stats_table.php
+++ b/database/migrations/2025_07_13_235713_create_pitcher_stats_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pitcher_stats', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->date('match_date');
+            $table->string('opponent_team');
+            $table->float('innings_pitched')->default(0);
+            $table->integer('hits_allowed')->default(0);
+            $table->integer('strikeouts')->default(0);
+            $table->integer('walks')->default(0);
+            $table->integer('earned_runs')->default(0);
+            $table->boolean('win')->default(false);
+            $table->boolean('save')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pitcher_stats');
+    }
+};

--- a/database/migrations/2025_07_13_235800_create_favorites_table.php
+++ b/database/migrations/2025_07_13_235800_create_favorites_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('favorites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('favorites');
+    }
+};

--- a/database/migrations/2025_07_13_235839_create_external_api_sources_table.php
+++ b/database/migrations/2025_07_13_235839_create_external_api_sources_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('external_api_sources', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->string('source_name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('external_api_sources');
+    }
+};

--- a/database/migrations/2025_07_14_001242_add_role_to_users_table.php
+++ b/database/migrations/2025_07_14_001242_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->enum('role', ['user', 'admin'])->default('user')->after('password');
+    });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
## 概要

選手名鑑アプリの基本データ構造に関するマイグレーションファイルを追加しました。

##主な変更内容

- users テーブルに role カラムを追加（admin 判定用）
- teams テーブル：チーム名・略称・ロゴURL
- players テーブル：選手情報（背番号、所属チームなど）
- positions テーブル：守備位置情報
- player_position テーブル：選手とポジションの多対多リレーション
- batter_stats テーブル：打者成績（試合単位）
- pitcher_stats テーブル：投手成績（試合単位）
- favorites テーブル：ユーザーのお気に入り登録用
- external_api_sources テーブル：外部成績取得元の追跡用

## マイグレーション実行

```bash
./vendor/bin/sail artisan migrate