### PR TITLE
refactor : vite-tailwindcss-vesionup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
                 "@inertiajs/vue3": "^2.0.0",
                 "@tailwindcss/forms": "^0.5.3",
                 "@tailwindcss/vite": "^4.0.0",
-                "@vitejs/plugin-vue": "^5.0.0",
-                "autoprefixer": "^10.4.12",
+                "@vitejs/plugin-vue": "^6.0.1",
+                "autoprefixer": "^10.4.21",
                 "axios": "^1.8.2",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.0.0",
-                "postcss": "^8.4.31",
-                "tailwindcss": "^3.2.1",
+                "postcss": "^8.5.6",
+                "tailwindcss": "^3.4.17",
                 "vite": "^7.0.4",
                 "vue": "^3.4.0"
             }
@@ -683,6 +683,13 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.29",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.29.tgz",
+            "integrity": "sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.46.2",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
@@ -1275,16 +1282,19 @@
             "license": "MIT"
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-            "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.1.tgz",
+            "integrity": "sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "1.0.0-beta.29"
+            },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
                 "vue": "^3.2.25"
             }
         },
@@ -2163,21 +2173,6 @@
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
             }
         },
         "node_modules/fill-range": {
@@ -3884,6 +3879,21 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.4.6",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/tinyglobby/node_modules/picomatch": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -4056,6 +4066,21 @@
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/vite/node_modules/fdir": {
+            "version": "6.4.6",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vite/node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
         "@inertiajs/vue3": "^2.0.0",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/vite": "^4.0.0",
-        "@vitejs/plugin-vue": "^5.0.0",
-        "autoprefixer": "^10.4.12",
+        "@vitejs/plugin-vue": "^6.0.1",
+        "autoprefixer": "^10.4.21",
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",
-        "postcss": "^8.4.31",
-        "tailwindcss": "^3.2.1",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^3.4.17",
         "vite": "^7.0.4",
         "vue": "^3.4.0"
     }


### PR DESCRIPTION
@vitejs/plugin-vue  : 5.0.0 → 6.0.1
autoprefixer : 10.4.12 → 10.4.21
postcss : 8.4.31 → 8.5.6
tailwindcss : 3.2.1 → 3.4.17

それぞれバージョンアップ対応