### PR TITLE
feat: APIルーティングの設定およびMCity関連のエンドポイントとタイポ修正

### DIFF
--- a/app/Http/Controllers/MCityController.php
+++ b/app/Http/Controllers/MCityController.php
@@ -3,12 +3,13 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\MCity;
 
 class MCityController extends Controller
 {
     public function getByPrefecture($prefecture)
     {
-        $cities = MCity::where('prefectures_id', $prefecture)->get();
+        $cities = MCity::where('prefecture_id', $prefecture)->get();
         return response()->json($cities);
     }
 }

--- a/app/Models/MCity.php
+++ b/app/Models/MCity.php
@@ -6,7 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class MCity extends Model
 {
-    protected $fillable = ['name', 'prefectures_id'];
+    protected $table = 'm_cities';
+    protected $fillable = ['name', 'prefecture_id'];
 
     public function players() {
         return $this->hasMany(TPlayer::class, 'city_id');

--- a/app/Models/TPlayer.php
+++ b/app/Models/TPlayer.php
@@ -7,6 +7,9 @@ use SoftDeletes;
 
 class TPlayer extends Model
 {
+
+    public $timestamps = false;
+    
     public function position(){
         return $this->belongsTo(MPosition::class, 'position_id');
     }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        parent::boot();
+        
+        $this->routes(function () {
+            Route::middleware('api')
+                ->prefix('api')
+                ->group(base_path('routes/api.php'));
+
+            Route::middleware('web')
+                ->group(base_path('routes/web.php'));
+        });
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\RouteServiceProvider::class,
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,4 +3,4 @@
 use App\Http\Controllers\MCityController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('prefectures/{prefecture}/citys', [MCityController::class, 'getByPrefecture']);
+Route::get('prefectures/{prefecture}/cities', [MCityController::class, 'getByPrefecture']);


### PR DESCRIPTION
以下の変更を含みます：

- `RouteServiceProvider.php` を追加し、`routes/api.php` を正しく読み込むように設定
- `providers.php`に `RouteServiceProvider` を登録
- `routes/api.php` に `/prefectures/{prefecture}/cities` エンドポイントを追加
- `MCityController.php` の `getByPrefecture` メソッド内の `prefectures_id` を正しく `prefecture_id` に修正
- `MCity.php` モデルの`prefectures_id` を正しく `prefecture_id` に修正

このPRによって、Vue側からの API リクエストが 404 になっていた問題が解消され、都道府県ごとの市区町村取得が機能するようになります。
